### PR TITLE
Add missing closing quote in sample .babelrc config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Each loader accepts a `loading` prop as a boolean. The loader will not render an
 
 ```
 {
-    "presets": ["@babel/preset-react", "@babel/preset-env],
+    "presets": ["@babel/preset-react", "@babel/preset-env"],
     "plugins": ["emotion"]
 }
 ```


### PR DESCRIPTION
Adds the missing closing quote in the .babelrc configuration section of the README.